### PR TITLE
Update to Android SDK Build Tools 24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ FROM ubuntu:16.04
 MAINTAINER Jan Grewe <jan@faked.org>
 
 ENV VERSION_SDK_TOOLS "25.1.7"
-ENV VERSION_BUILD_TOOLS "23.0.3"
-ENV VERSION_TARGET_SDK "23"
+ENV VERSION_BUILD_TOOLS "24"
+ENV VERSION_TARGET_SDK "24"
 
 ENV SDK_PACKAGES "build-tools-${VERSION_BUILD_TOOLS},android-${VERSION_TARGET_SDK},addon-google_apis-google-${VERSION_TARGET_SDK},platform-tools,extra-android-m2repository,extra-android-support,extra-google-google_play_services,extra-google-m2repository"
 


### PR DESCRIPTION
The Android SDK Build Tools got an update to version 24. Also, target SDK is incremented to version 24. This closes #2.
