### PR TITLE
Add Git packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -qq update && \
     apt-get install -qqy --no-install-recommends \
       curl \
+      git-all \
       html2text \
       openjdk-8-jdk \
       libc6-i386 \


### PR DESCRIPTION
This PR adds the git-all package to the docker image.

This allows gradle builds scripts to use git functionality. For example, Providing git sha, build time and version information from a git tag. This can then be fed into the application using build config fields.

Some functionality is demonstraided by Jake Wharton here: https://plus.google.com/+JakeWharton/posts/6f5TcVPRZij