### PR TITLE
Add new license key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN curl -s https://dl.google.com/android/repository/sdk-tools-linux-${VERSION_S
     rm -v /sdk.zip
 
 RUN mkdir -p $ANDROID_HOME/licenses/ \
-  && echo "8933bad161af4178b1185d1a37fbf41ea5269c55" > $ANDROID_HOME/licenses/android-sdk-license \
+  && echo "8933bad161af4178b1185d1a37fbf41ea5269c55\nd56f5187479451eabf01fb78af6dfcb131a6481e" > $ANDROID_HOME/licenses/android-sdk-license \
   && echo "84831b9409646a918e30573bab4c9c91346d8abd" > $ANDROID_HOME/licenses/android-sdk-preview-license
 
 ADD packages.txt /sdk


### PR DESCRIPTION
Android updated the SDK license. This causes issues outlined in #25.  Adding this new string to the SDK license key file corrects the problem