### PR TITLE
fix: non ASCII env build fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,10 @@ RUN apt-get -qq update && \
       lib32ncurses5 \
       lib32z1 \
       unzip \
+      locales \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN locale-gen en_US.UTF-8
+ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
 RUN rm -f /etc/ssl/certs/java/cacerts; \
     /var/lib/dpkg/info/ca-certificates-java.postinst configure


### PR DESCRIPTION
build failed when env variable contains non ASCII
error message: Gradle build daemon disappeared unexpectedly 
ref #39 

reproduce:
- submit commit with a non ascii comment (CI_COMMIT_MESSAGE)
- or GITLAB_USER_NAME contains non ascii 

