### PR TITLE
Change openjdk version from 11 to 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get -qq update \
       curl \
       git-core \
       html2text \
-      openjdk-11-jdk \
+      openjdk-8-jdk \
       libc6-i386 \
       lib32stdc++6 \
       lib32gcc1 \


### PR DESCRIPTION
Hi!
When I build app in release with minify, I've got this error 
```
/usr/lib/jvm/java-11-openjdk-amd64/lib/rt.jar: R8: File not found: /usr/lib/jvm/java-11-openjdk-amd64/lib/rt.jar
> Task :app:minifyBetaWithR8 FAILED
```
Because compileOptions is
![image](https://user-images.githubusercontent.com/9414578/96083328-6b3ecc80-0ed6-11eb-8da0-00af487d1bd0.png)
