### PR TITLE
Is the path correct?

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ build:
   - ./gradlew assembleDebug
   artifacts:
     paths:
-    - app/build/outputs/apk/app-debug.apk
+    - app/build/outputs/apk/debug/app-debug.apk
 ```


### PR DESCRIPTION
When testing the image, I noticed that the path given in the `README.md` leads to the error message 

```
WARNING: app/build/outputs/apk/app-debug.apk: no matching files 
ERROR: No files to upload    
```                      

In fact, the folder "debug" is missing. The correct path is

`app/build/outputs/apk/debug/app-debug.apk`
