### PR TITLE
Update command line tools version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 MAINTAINER Jan Grewe <jan@faked.org>
 
-ENV VERSION_TOOLS "8512546"
+ENV VERSION_TOOLS "9123335"
 
 ENV ANDROID_SDK_ROOT "/sdk"
 # Keep alias for compatibility


### PR DESCRIPTION
Update VERSION_TOOLS field to 9123335 which is currently the latest version of the command line tools. I haven't made any test with this change.