### PR TITLE
Now using JDK 17.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get -qq update \
       curl \
       git-core \
       html2text \
-      openjdk-11-jdk \
+      openjdk-17-jdk \
       libc6-i386 \
       lib32stdc++6 \
       lib32gcc1 \


### PR DESCRIPTION
New Android Gradle Plugin (8.0.0) requires JDK 17.

https://developer.android.com/build/releases/gradle-plugin#groovy
