### PR TITLE
Use gitlab-runner as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM gitlab/gitlab-runner:latest
 MAINTAINER Jan Grewe <jan@faked.org>
 
 ENV VERSION_TOOLS "8512546"


### PR DESCRIPTION
Gitlab now has some [base images](https://docs.gitlab.com/runner/install/docker.html#docker-images) available to extend. They are relatively simple, but still can be useful